### PR TITLE
Bug fix: Improve collection element deserialization with $type metadata [Estimate: 5]


### DIFF
--- a/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
+++ b/Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs
@@ -1696,19 +1696,58 @@ namespace Newtonsoft.Json.Serialization
                                 break;
                             case JsonToken.Comment:
                                 break;
+                            case JsonToken.StartObject:
+                                // Check for $type metadata to handle TypeNameHandling.All for collection elements
+                                if (Serializer._typeNameHandling != TypeNameHandling.None)
+                                {
+                                    // Save position to restore if needed
+                                    if (reader is JTokenReader tokenReader)
+                                    {
+                                        JObject obj = (JObject)tokenReader.CurrentToken!;
+                                        JToken? typeToken;
+                                        if (obj.TryGetValue(JsonTypeReflector.TypePropertyName, StringComparison.Ordinal, out typeToken))
+                                        {
+                                            string? typeName = (string?)typeToken;
+                                            if (!string.IsNullOrEmpty(typeName))
+                                            {
+                                                Type? specificType = null;
+                                                try
+                                                {
+                                                    StructMultiKey<string?, string> typeNameKey = ReflectionUtils.SplitFullyQualifiedTypeName(typeName);
+                                                    specificType = Serializer._serializationBinder.BindToType(typeNameKey.Value1, typeNameKey.Value2);
+                                                }
+                                                catch (Exception)
+                                                {
+                                                    // Ignore binding errors here - will be caught later if needed
+                                                }
+
+                                                // If we found a concrete type that's not a collection, deserialize directly to avoid wrapping
+                                                if (specificType != null && 
+                                                    !typeof(IEnumerable).IsAssignableFrom(specificType) && 
+                                                    specificType != typeof(string))
+                                                {
+                                                    object? value = Serializer.Deserialize(reader, specificType);
+                                                    list.Add(value);
+                                                    continue;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                                goto default;
                             default:
-                                object? value;
+                                object? elementValue;
 
                                 if (collectionItemConverter != null && collectionItemConverter.CanRead)
                                 {
-                                    value = DeserializeConvertable(collectionItemConverter, reader, contract.CollectionItemType, null);
+                                    elementValue = DeserializeConvertable(collectionItemConverter, reader, contract.CollectionItemType, null);
                                 }
                                 else
                                 {
-                                    value = CreateValueInternal(reader, contract.CollectionItemType, contract.ItemContract, null, contract, containerProperty, null);
+                                    elementValue = CreateValueInternal(reader, contract.CollectionItemType, contract.ItemContract, null, contract, containerProperty, null);
                                 }
 
-                                list.Add(value);
+                                list.Add(elementValue);
                                 break;
                         }
                     }


### PR DESCRIPTION



___

### **User description**
https://github.com/JamesNK/Newtonsoft.Json/issues/3051


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes deserialization of collection elements with `$type` metadata
  - Detects and binds to specific element type using `$type`
  - Avoids wrapping non-collection types in collections
  - Handles type binding errors gracefully

- Refactors variable naming for clarity in element value assignment


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>JsonSerializerInternalReader.cs</strong><dd><code>Enhance collection deserialization with $type metadata support</code></dd></summary>
<hr>

Src/Newtonsoft.Json/Serialization/JsonSerializerInternalReader.cs

<li>Adds logic to detect <code>$type</code> metadata in collection elements<br> <li> Binds to specific type and deserializes directly if not a collection<br> <li> Refactors variable naming for clarity (<code>value</code> to <code>elementValue</code>)<br> <li> Handles type binding errors gracefully, continuing deserialization


</details>


  </td>
  <td><a href="https://github.com/David-Parry/Newtonsoft.Json/pull/1/files#diff-0cad9ba49a9e46b4ec6768f54198533ebbdea5733b5c66d1683510459eb756cc">+43/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>